### PR TITLE
Blog hero zoom + readable italics

### DIFF
--- a/src/blog.css
+++ b/src/blog.css
@@ -12,6 +12,29 @@
     margin-bottom: 2.5rem;
 }
 
+/* Header image — larger than the global 40vmin, sized to fit either a wide
+   diagram or a tall portrait while staying responsive */
+.blog-page .App-logo {
+    height: auto;
+    width: auto;
+    max-width: min(820px, 92vw);
+    max-height: 72vh;
+    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+}
+
+/* Click the hero to open the full-resolution image in a new tab (zoom) */
+.blog-page .hero-zoom {
+    display: inline-block;
+    cursor: zoom-in;
+    border-bottom: none;
+    transition: opacity 0.2s;
+}
+
+.blog-page .hero-zoom:hover {
+    opacity: 0.92;
+}
+
 /* Category label — the abstract becomes an ALL-CAPS editorial label */
 .blog-page .Abstract {
     display: block;

--- a/src/blog.css
+++ b/src/blog.css
@@ -159,7 +159,7 @@
 }
 
 .blog-page .Content em {
-    color: var(--text-muted);
+    color: var(--text-bright);
     font-style: italic;
 }
 

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -48,7 +48,15 @@ function Blog({
                 )}
                 <em className="Abstract">{abstract}</em>
                 <figure>
-                    <img src={img} className="App-logo" alt={caption} />
+                    <a
+                        href={img}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="hero-zoom"
+                        title="Click to open full size"
+                    >
+                        <img src={img} className="App-logo" alt={caption} />
+                    </a>
                     <figcaption className="Caption">{caption}</figcaption>
                 </figure>
             </header>


### PR DESCRIPTION
Two readability improvements to article pages.

## 1. Larger, zoomable header image
- Article hero images render larger and responsive (up to 820px wide / 72vh tall, fitting either a wide diagram or a tall portrait) instead of the old fixed `40vmin`.
- The hero is now wrapped in a link that opens the full-resolution image in a new tab, giving native zoom/pan (works well on mobile). Adds a zoom-in cursor + subtle hover affordance.
- Primarily for the Lean article's flywheel diagram, but applies consistently to all post heroes.

## 2. More readable italics
- Italic (`em`) body text used `--text-muted` (#888) — *dimmer* than the #c8c8c8 body text, so emphasis was harder to read. Switched to `--text-bright` so italics stand out instead of fading.

## Verification
- `npm run build` (deploy-equivalent, no `CI` flag) → exit 0, "Compiled with warnings" (only the pre-existing repo-wide lint warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ECDHmNuxM6qcEqaSCevML

---
_Generated by [Claude Code](https://claude.ai/code/session_014ECDHmNuxM6qcEqaSCevML)_