### PR TITLE
Fix article text clipped at both edges on mobile

### DIFF
--- a/src/blog.css
+++ b/src/blog.css
@@ -17,7 +17,7 @@
 .blog-page .App-logo {
     height: auto;
     width: auto;
-    max-width: min(820px, 92vw);
+    max-width: 100%;
     max-height: 72vh;
     border-radius: 8px;
     border: 1px solid var(--border-subtle);

--- a/src/index.css
+++ b/src/index.css
@@ -189,6 +189,13 @@ body {
     }
 }
 
+.Article {
+    /* include the left/right padding in the width so the text column never
+       overflows the viewport (which clips both edges under overflow-x:hidden) */
+    width: 100%;
+    box-sizing: border-box;
+}
+
 .Article-header {
     text-align: center;
 }


### PR DESCRIPTION
Fixes body text being cut off at both left and right edges (most visible on mobile).

## Cause
`.Article` has horizontal padding (`0 7%` mobile / `0 25%` desktop) but no `box-sizing: border-box`, so the padding was added *on top of* the element's full width. The centered text column ended up wider than the viewport, and with `overflow-x: hidden` the excess was clipped on both sides instead of scrolling. The hero image was unaffected only because it has its own `max-width`.

## Fix
- `.Article` → `width: 100%` + `box-sizing: border-box`, so the padding is included in the width and the text column stays within the viewport and wraps correctly.
- Hero image `max-width: 100%` (respects the content column) instead of `92vw` (viewport-relative).

## Verification
- `npm run build` (deploy-equivalent, no `CI` flag) → exit 0, "Compiled with warnings" (pre-existing repo-wide lint warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ECDHmNuxM6qcEqaSCevML

---
_Generated by [Claude Code](https://claude.ai/code/session_014ECDHmNuxM6qcEqaSCevML)_