### PR TITLE
Lean'in' to Grad School: remove stray flywheel bullet list

### DIFF
--- a/src/articles/LeanInToGradSchool.tsx
+++ b/src/articles/LeanInToGradSchool.tsx
@@ -338,24 +338,6 @@ const LeanInToGradSchool: ArticleProps = {
             </strong>{' '}
             There has never been a better time to be a builder.
         </p>,
-        <hr />,
-        <p>
-            <strong>The Flywheel:</strong>
-        </p>,
-        <ol>
-            <li>
-                <strong>AI × SWE</strong> → Accelerate Code ✅
-            </li>
-            <li>
-                <strong>SWE × Verification</strong> → Prove Correct ✅
-            </li>
-            <li>
-                <strong>Verification × Math</strong> → Formalize Truths ✅
-            </li>
-            <li>
-                <strong>Math × AI</strong> → Build Math Machines ✅
-            </li>
-        </ol>,
     ],
 };
 


### PR DESCRIPTION
Removes the closing "The Flywheel:" ordered list (and its preceding divider) from the `/lean` article — it wasn't meant to be published.

## Verification
- `npm run build` (deploy-equivalent, no `CI` flag) → exit 0, "Compiled with warnings" (pre-existing repo-wide lint warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ECDHmNuxM6qcEqaSCevML

---
_Generated by [Claude Code](https://claude.ai/code/session_014ECDHmNuxM6qcEqaSCevML)_