### PR TITLE
feat: add blog analytics with Excel storage and dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,14 +103,14 @@ Dashboard        ◄── GET /api/personal/analytics ◄───────�
 - `src/personal/analytics/api.ts` — Fetch helpers
 - Route: `/personal/analytics` (behind auth)
 
-**Excel workbook setup (manual, one-time):**
+**Excel workbook setup (provisioned):**
 
-Create `/PersonalApps/blog-analytics.xlsx` in OneDrive with a table named `Events` and these column headers:
+`/PersonalApps/blog-analytics.xlsx` exists in OneDrive with an `Events` table and these column headers:
 
 | timestamp | session_id | event | route | referrer | device | read_seconds |
 |-----------|------------|-------|-------|----------|--------|--------------|
 
-The existing Graph API credentials already have `Files.ReadWrite` scope — no new permissions needed.
+It was created with `npx tsx scripts/create-analytics-workbook.ts` (idempotent — re-run to recreate the workbook/table if it's ever deleted). The existing Graph API credentials already have `Files.ReadWrite` scope — no new permissions needed.
 
 **How tracking hooks in:**
 - `Blog.tsx` calls `usePageTracking(route)` — tracks view on mount, sends read time on unmount/tab-switch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,63 @@ videoSrc: 'https://kennethjusinoblog.blob.core.windows.net/videos/my-video.mp4',
 > These are **public** blog videos (no confidentiality). For private/gated video
 > you'd need a private container + server-minted SAS URLs + a VideoPlayer change —
 > a different design, not what's set up here.
+
+### Analytics (implemented)
+
+Tracks visitor engagement across all articles and stores data in Microsoft Excel via Graph API.
+
+**What's tracked** (all automatic, no per-article wiring needed):
+- `view` — page load (deduplicated per session)
+- `audio_play` / `audio_complete` — audio playback start and finish
+- `video_play` / `video_complete` — video playback start and finish
+- `read_seconds` — time spent on page (sent on tab switch or navigation)
+- `referrer` — external hostname that linked to the page
+- `device` — desktop / mobile / tablet (from user agent)
+- `session_id` — random UUID per browser session (`sessionStorage`)
+
+**Architecture:**
+
+```
+Browser (public)                    Express Server                    Microsoft Graph
+─────────────────                   ──────────────                    ───────────────
+Blog.tsx         ──► POST /api/analytics/event ──► in-memory buffer
+AudioPlayer.tsx  ──►   (no auth, rate-limited)      │
+VideoPlayer.tsx  ──►                                 ├──► flush every 2min ──► Excel append
+                                                     │    or when buffer ≥ 50
+Dashboard        ◄── GET /api/personal/analytics ◄──────── Excel read ◄── /PersonalApps/blog-analytics.xlsx
+(requireAuth)         /summary
+```
+
+**Server files:**
+- `server/analytics/excel.ts` — Graph API read/write for the analytics workbook
+- `server/analytics/buffer.ts` — In-memory event buffer with timed flush (2min / 50 events)
+- `server/analytics/cache.ts` — 5-min TTL cache for dashboard reads; aggregates per-route stats
+- `server/routes/analytics.ts` — Public `POST /api/analytics/event` (rate-limited: 30 req/min/IP) + auth'd `GET /api/personal/analytics/summary` and `POST /api/personal/analytics/refresh`
+
+**Client files:**
+- `src/analytics/tracker.ts` — `trackEvent()` using `navigator.sendBeacon()` (fire-and-forget), with per-session dedup
+- `src/analytics/usePageTracking.ts` — React hook for views + read time (called in `Blog.tsx`)
+
+**Dashboard:**
+- `src/personal/analytics/Analytics.tsx` — Summary cards (views, sessions, audio plays, video plays), per-article table, top referrers, device breakdown
+- `src/personal/analytics/analytics.css` — Dashboard styles
+- `src/personal/analytics/api.ts` — Fetch helpers
+- Route: `/personal/analytics` (behind auth)
+
+**Excel workbook setup (manual, one-time):**
+
+Create `/PersonalApps/blog-analytics.xlsx` in OneDrive with a table named `Events` and these column headers:
+
+| timestamp | session_id | event | route | referrer | device | read_seconds |
+|-----------|------------|-------|-------|----------|--------|--------------|
+
+The existing Graph API credentials already have `Files.ReadWrite` scope — no new permissions needed.
+
+**How tracking hooks in:**
+- `Blog.tsx` calls `usePageTracking(route)` — tracks view on mount, sends read time on unmount/tab-switch
+- `AudioPlayer.tsx` and `VideoPlayer.tsx` accept a `route` prop and call `trackEvent()` on play/ended events
+- Blog.tsx passes `route` down to both media players
+
+**Rate limiting:** Simple in-memory Map per IP, 30 requests per 60-second window. No npm dependency (no `express-rate-limit`).
+
+**No cookies or fingerprinting.** Session ID lives in `sessionStorage` (cleared when the tab closes). Referrer is the external hostname only (same-site navigations are ignored).

--- a/scripts/create-analytics-workbook.ts
+++ b/scripts/create-analytics-workbook.ts
@@ -1,0 +1,125 @@
+/**
+ * One-time setup: create /PersonalApps/blog-analytics.xlsx in OneDrive with an
+ * `Events` table whose columns match server/analytics/excel.ts (EventRow).
+ *
+ * Idempotent — safe to re-run. Reuses the app's Microsoft Graph credentials.
+ *
+ * Run from the blogger repo root:
+ *   npx tsx scripts/create-analytics-workbook.ts
+ */
+import { getAccessToken } from '../server/integrations/msTokens';
+
+const GRAPH = 'https://graph.microsoft.com/v1.0';
+const WORKBOOK_PATH = '/PersonalApps/blog-analytics.xlsx';
+const TABLE = 'Events';
+const HEADERS = [
+    'timestamp',
+    'session_id',
+    'event',
+    'route',
+    'referrer',
+    'device',
+    'read_seconds',
+];
+const XLSX_MIME =
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+async function g(
+    pathOrUrl: string,
+    init: RequestInit = {},
+    rawBody = false
+): Promise<Response> {
+    const token = await getAccessToken();
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        ...((init.headers as Record<string, string>) || {}),
+    };
+    if (!rawBody) headers['Content-Type'] = 'application/json';
+    const url = pathOrUrl.startsWith('http') ? pathOrUrl : `${GRAPH}${pathOrUrl}`;
+    return fetch(url, { ...init, headers });
+}
+
+const item = (p: string) => `/me/drive/root:${p}`;
+const wb = (p: string) => `${item(p)}:/workbook`;
+
+async function ensureWorkbookFile(): Promise<void> {
+    const exists = await g(item(WORKBOOK_PATH));
+    if (exists.ok) {
+        console.log('• workbook file already exists');
+        return;
+    }
+    console.log('• creating empty workbook file…');
+    const put = await g(
+        `${item(WORKBOOK_PATH)}:/content`,
+        { method: 'PUT', body: new Uint8Array(0), headers: { 'Content-Type': XLSX_MIME } },
+        true
+    );
+    if (!put.ok) throw new Error(`create file failed: ${put.status} ${await put.text()}`);
+    console.log('  created.');
+}
+
+async function firstSheetName(): Promise<string> {
+    const res = await g(`${wb(WORKBOOK_PATH)}/worksheets`);
+    if (!res.ok) throw new Error(`worksheets read failed: ${res.status} ${await res.text()}`);
+    const json = (await res.json()) as { value: { name: string }[] };
+    if (!json.value?.length) throw new Error('workbook has no worksheets');
+    return json.value[0].name;
+}
+
+async function tableExists(): Promise<boolean> {
+    const res = await g(`${wb(WORKBOOK_PATH)}/tables('${TABLE}')`);
+    return res.ok;
+}
+
+async function createEventsTable(sheet: string): Promise<void> {
+    console.log(`• writing headers to ${sheet}!A1:G1…`);
+    const hdr = await g(
+        `${wb(WORKBOOK_PATH)}/worksheets('${sheet}')/range(address='A1:G1')`,
+        { method: 'PATCH', body: JSON.stringify({ values: [HEADERS] }) }
+    );
+    if (!hdr.ok) throw new Error(`header write failed: ${hdr.status} ${await hdr.text()}`);
+
+    console.log('• adding table over A1:G1…');
+    const add = await g(`${wb(WORKBOOK_PATH)}/tables/add`, {
+        method: 'POST',
+        body: JSON.stringify({ address: `${sheet}!A1:G1`, hasHeaders: true }),
+    });
+    if (!add.ok) throw new Error(`table add failed: ${add.status} ${await add.text()}`);
+    const created = (await add.json()) as { name: string };
+
+    if (created.name !== TABLE) {
+        console.log(`• renaming table '${created.name}' -> '${TABLE}'…`);
+        const ren = await g(`${wb(WORKBOOK_PATH)}/tables('${created.name}')`, {
+            method: 'PATCH',
+            body: JSON.stringify({ name: TABLE }),
+        });
+        if (!ren.ok) throw new Error(`rename failed: ${ren.status} ${await ren.text()}`);
+    }
+}
+
+async function verify(): Promise<void> {
+    const res = await g(`${wb(WORKBOOK_PATH)}/tables('${TABLE}')/columns`);
+    if (!res.ok) throw new Error(`verify failed: ${res.status} ${await res.text()}`);
+    const json = (await res.json()) as { value: { name: string }[] };
+    const names = json.value.map((c) => c.name);
+    const ok = JSON.stringify(names) === JSON.stringify(HEADERS);
+    console.log('• verify columns:', names, ok ? '✅ match' : '❌ MISMATCH');
+    if (!ok) throw new Error('column headers do not match EventRow');
+}
+
+async function main() {
+    await ensureWorkbookFile();
+    if (await tableExists()) {
+        console.log('• Events table already exists — verifying only');
+    } else {
+        const sheet = await firstSheetName();
+        await createEventsTable(sheet);
+    }
+    await verify();
+    console.log('\n✅ blog-analytics.xlsx ready with Events table.');
+}
+
+main().catch((e) => {
+    console.error('FAILED:', e);
+    process.exit(1);
+});

--- a/server/analytics/buffer.ts
+++ b/server/analytics/buffer.ts
@@ -1,0 +1,29 @@
+import { appendEvents, EventRow } from './excel';
+
+const buffer: EventRow[] = [];
+const FLUSH_THRESHOLD = 50;
+const FLUSH_INTERVAL_MS = 2 * 60 * 1000;
+
+export function enqueue(row: EventRow): void {
+    buffer.push(row);
+    if (buffer.length >= FLUSH_THRESHOLD) {
+        flush();
+    }
+}
+
+export async function flush(): Promise<void> {
+    if (buffer.length === 0) return;
+    const batch = buffer.splice(0);
+    try {
+        await appendEvents(batch);
+    } catch (e) {
+        console.error('[analytics] flush failed, re-queuing', e);
+        buffer.unshift(...batch);
+    }
+}
+
+export function startFlusher(): void {
+    setInterval(() => {
+        flush().catch((e) => console.error('[analytics] flush error', e));
+    }, FLUSH_INTERVAL_MS);
+}

--- a/server/analytics/cache.ts
+++ b/server/analytics/cache.ts
@@ -1,0 +1,140 @@
+import { readAllEvents, EventRow } from './excel';
+
+export interface ArticleStats {
+    route: string;
+    views: number;
+    uniqueSessions: number;
+    audioPlays: number;
+    audioCompletes: number;
+    videoPlays: number;
+    videoCompletes: number;
+    avgReadSeconds: number;
+}
+
+export interface AnalyticsSummary {
+    totalViews: number;
+    uniqueSessions: number;
+    totalAudioPlays: number;
+    totalVideoPlays: number;
+    articles: ArticleStats[];
+    topReferrers: { referrer: string; count: number }[];
+    devices: { device: string; count: number; percent: number }[];
+}
+
+const TTL_MS = 5 * 60 * 1000;
+
+let cached: { summary: AnalyticsSummary; expiresAt: number } | null = null;
+let inflight: Promise<AnalyticsSummary> | null = null;
+
+function buildSummary(rows: EventRow[]): AnalyticsSummary {
+    const allSessions = new Set<string>();
+    const routeMap = new Map<string, EventRow[]>();
+    const referrerCounts = new Map<string, number>();
+    const deviceCounts = new Map<string, number>();
+
+    for (const r of rows) {
+        allSessions.add(r.session_id);
+
+        let bucket = routeMap.get(r.route);
+        if (!bucket) { bucket = []; routeMap.set(r.route, bucket); }
+        bucket.push(r);
+
+        if (r.referrer) {
+            referrerCounts.set(r.referrer, (referrerCounts.get(r.referrer) ?? 0) + 1);
+        }
+
+        if (r.event === 'view') {
+            deviceCounts.set(r.device, (deviceCounts.get(r.device) ?? 0) + 1);
+        }
+    }
+
+    let totalViews = 0;
+    let totalAudioPlays = 0;
+    let totalVideoPlays = 0;
+
+    const articles: ArticleStats[] = [];
+    for (const [route, events] of routeMap) {
+        const sessions = new Set<string>();
+        let views = 0, audioPlays = 0, audioCompletes = 0;
+        let videoPlays = 0, videoCompletes = 0;
+        let readSecondsSum = 0, readSecondsCount = 0;
+
+        for (const e of events) {
+            sessions.add(e.session_id);
+            switch (e.event) {
+                case 'view':
+                    views++;
+                    if (e.read_seconds > 0) {
+                        readSecondsSum += e.read_seconds;
+                        readSecondsCount++;
+                    }
+                    break;
+                case 'audio_play': audioPlays++; break;
+                case 'audio_complete': audioCompletes++; break;
+                case 'video_play': videoPlays++; break;
+                case 'video_complete': videoCompletes++; break;
+            }
+        }
+
+        totalViews += views;
+        totalAudioPlays += audioPlays;
+        totalVideoPlays += videoPlays;
+
+        articles.push({
+            route,
+            views,
+            uniqueSessions: sessions.size,
+            audioPlays,
+            audioCompletes,
+            videoPlays,
+            videoCompletes,
+            avgReadSeconds: readSecondsCount > 0 ? Math.round(readSecondsSum / readSecondsCount) : 0,
+        });
+    }
+
+    articles.sort((a, b) => b.views - a.views);
+
+    const topReferrers = Array.from(referrerCounts.entries())
+        .map(([referrer, count]) => ({ referrer, count }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 20);
+
+    const totalDeviceViews = Array.from(deviceCounts.values()).reduce((a, b) => a + b, 0);
+    const devices = Array.from(deviceCounts.entries())
+        .map(([device, count]) => ({
+            device,
+            count,
+            percent: totalDeviceViews > 0 ? Math.round((count / totalDeviceViews) * 100) : 0,
+        }))
+        .sort((a, b) => b.count - a.count);
+
+    return {
+        totalViews,
+        uniqueSessions: allSessions.size,
+        totalAudioPlays,
+        totalVideoPlays,
+        articles,
+        topReferrers,
+        devices,
+    };
+}
+
+export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
+    if (cached && Date.now() < cached.expiresAt) return cached.summary;
+    if (inflight) return inflight;
+    inflight = (async () => {
+        try {
+            const rows = await readAllEvents();
+            const summary = buildSummary(rows);
+            cached = { summary, expiresAt: Date.now() + TTL_MS };
+            return summary;
+        } finally {
+            inflight = null;
+        }
+    })();
+    return inflight;
+}
+
+export function bustAnalyticsCache(): void {
+    cached = null;
+}

--- a/server/analytics/excel.ts
+++ b/server/analytics/excel.ts
@@ -1,0 +1,93 @@
+import { getAccessToken } from '../integrations/msTokens';
+
+export type EventRow = {
+    timestamp: string;
+    session_id: string;
+    event: string;
+    route: string;
+    referrer: string;
+    device: string;
+    read_seconds: number;
+};
+
+const WORKBOOK_PATH = '/PersonalApps/blog-analytics.xlsx';
+const TABLE = 'Events';
+const GRAPH = 'https://graph.microsoft.com/v1.0';
+
+function tableUrl(): string {
+    return `${GRAPH}/me/drive/root:${WORKBOOK_PATH}:/workbook/tables('${TABLE}')`;
+}
+
+async function graphFetch(url: string, init: RequestInit = {}): Promise<Response> {
+    const token = await getAccessToken();
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        ...((init.headers as Record<string, string>) || {}),
+    };
+    return fetch(url, { ...init, headers });
+}
+
+const COLS: (keyof EventRow)[] = [
+    'timestamp',
+    'session_id',
+    'event',
+    'route',
+    'referrer',
+    'device',
+    'read_seconds',
+];
+
+function escapeFormula(v: unknown): unknown {
+    if (typeof v === 'string' && /^[=+\-@]/.test(v)) return "'" + v;
+    return v;
+}
+
+function unescape(s: unknown): string {
+    const str = String(s ?? '');
+    return str.startsWith("'") ? str.slice(1) : str;
+}
+
+export async function appendEvents(rows: EventRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    const values = rows.map((r) => COLS.map((c) => escapeFormula(r[c])));
+    const res = await graphFetch(`${tableUrl()}/rows`, {
+        method: 'POST',
+        body: JSON.stringify({ index: null, values }),
+    });
+    if (!res.ok) {
+        throw new Error(`Analytics append failed: ${res.status} ${await res.text()}`);
+    }
+}
+
+export async function readAllEvents(): Promise<EventRow[]> {
+    const out: EventRow[] = [];
+    let next: string | null = `${tableUrl()}/rows?$top=500`;
+    while (next) {
+        const res = await graphFetch(next);
+        if (!res.ok) {
+            throw new Error(`Analytics read failed: ${res.status} ${await res.text()}`);
+        }
+        const json = (await res.json()) as {
+            value: { values: unknown[][] }[];
+            '@odata.nextLink'?: string;
+        };
+        for (const row of json.value) {
+            const v = row.values?.[0];
+            if (!v) continue;
+            const ts = unescape(v[0]);
+            if (!ts) continue;
+            out.push({
+                timestamp: ts,
+                session_id: unescape(v[1]),
+                event: unescape(v[2]),
+                route: unescape(v[3]),
+                referrer: unescape(v[4]),
+                device: unescape(v[5]),
+                read_seconds: Number(v[6] ?? 0),
+            });
+        }
+        next = json['@odata.nextLink'] ?? null;
+    }
+    return out;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,8 @@ import { env } from './env';
 import { authRouter, requireAuth } from './auth';
 import { workoutRouter } from './routes/workout';
 import { leanlingoRouter } from './routes/leanlingo';
+import { analyticsPublicRouter, analyticsPrivateRouter } from './routes/analytics';
+import { startFlusher } from './analytics/buffer';
 
 const app = express();
 
@@ -29,6 +31,10 @@ app.use(cookieParser());
 app.use('/api/personal', authRouter);
 app.use('/api/personal/workout', requireAuth, workoutRouter);
 app.use('/api/personal/leanlingo', requireAuth, leanlingoRouter);
+app.use('/api/analytics', analyticsPublicRouter);
+app.use('/api/personal/analytics', requireAuth, analyticsPrivateRouter);
+
+startFlusher();
 
 const buildDir = path.resolve(__dirname, '..', 'build');
 app.use(express.static(buildDir));

--- a/server/routes/analytics.ts
+++ b/server/routes/analytics.ts
@@ -1,0 +1,85 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { enqueue } from '../analytics/buffer';
+import { getAnalyticsSummary, bustAnalyticsCache } from '../analytics/cache';
+import type { EventRow } from '../analytics/excel';
+
+const EventSchema = z.object({
+    event: z.enum(['view', 'audio_play', 'audio_complete', 'video_play', 'video_complete']),
+    route: z.string().min(1).max(100),
+    session_id: z.string().uuid(),
+    referrer: z.string().max(500).default(''),
+    device: z.enum(['desktop', 'mobile', 'tablet']),
+    read_seconds: z.number().int().min(0).max(86400).default(0),
+});
+
+// Simple in-memory rate limiter: max requests per window per IP
+const RATE_WINDOW_MS = 60 * 1000;
+const RATE_MAX = 30;
+const hits = new Map<string, { count: number; resetAt: number }>();
+
+function rateLimit(req: Request, res: Response): boolean {
+    const ip = req.ip ?? 'unknown';
+    const now = Date.now();
+    let entry = hits.get(ip);
+    if (!entry || now > entry.resetAt) {
+        entry = { count: 0, resetAt: now + RATE_WINDOW_MS };
+        hits.set(ip, entry);
+    }
+    entry.count++;
+    if (entry.count > RATE_MAX) {
+        res.status(429).json({ error: 'Too many requests' });
+        return false;
+    }
+    return true;
+}
+
+// Clean up stale entries every 5 minutes
+setInterval(() => {
+    const now = Date.now();
+    for (const [ip, entry] of hits) {
+        if (now > entry.resetAt) hits.delete(ip);
+    }
+}, 5 * 60 * 1000);
+
+export const analyticsPublicRouter = Router();
+
+analyticsPublicRouter.post('/event', (req: Request, res: Response) => {
+    if (!rateLimit(req, res)) return;
+
+    const parsed = EventSchema.safeParse(req.body);
+    if (!parsed.success) {
+        res.status(400).json({ error: 'invalid input', issues: parsed.error.issues });
+        return;
+    }
+
+    const row: EventRow = {
+        timestamp: new Date().toISOString(),
+        session_id: parsed.data.session_id,
+        event: parsed.data.event,
+        route: parsed.data.route,
+        referrer: parsed.data.referrer,
+        device: parsed.data.device,
+        read_seconds: parsed.data.read_seconds,
+    };
+
+    enqueue(row);
+    res.json({ ok: true });
+});
+
+export const analyticsPrivateRouter = Router();
+
+analyticsPrivateRouter.get('/summary', async (_req: Request, res: Response) => {
+    try {
+        const summary = await getAnalyticsSummary();
+        res.json(summary);
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        res.status(502).json({ error: msg });
+    }
+});
+
+analyticsPrivateRouter.post('/refresh', (_req: Request, res: Response) => {
+    bustAnalyticsCache();
+    res.json({ ok: true });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import PersonalIndex from './personal/Index';
 import Workout from './personal/workout/Workout';
 import LeanLingo from './personal/leanlingo/LeanLingo';
 import Reflex from './personal/reflex/Reflex';
+import Analytics from './personal/analytics/Analytics';
 
 const NON_BLOG_ROUTES = new Set(['/', '/cv', '/personal']);
 
@@ -46,6 +47,7 @@ function App() {
                         <Route path="workout" element={<Workout />} />
                         <Route path="leanlingo" element={<LeanLingo />} />
                         <Route path="reflex" element={<Reflex />} />
+                        <Route path="analytics" element={<Analytics />} />
                     </Route>
                 </Routes>
             </BrowserRouter>

--- a/src/analytics/tracker.ts
+++ b/src/analytics/tracker.ts
@@ -1,0 +1,66 @@
+const SID_KEY = 'analytics:sid';
+
+function getSessionId(): string {
+    let sid = sessionStorage.getItem(SID_KEY);
+    if (!sid) {
+        sid = crypto.randomUUID();
+        sessionStorage.setItem(SID_KEY, sid);
+    }
+    return sid;
+}
+
+function getDevice(): 'mobile' | 'tablet' | 'desktop' {
+    const ua = navigator.userAgent;
+    if (/Tablet|iPad/i.test(ua)) return 'tablet';
+    if (/Mobile|Android|iPhone/i.test(ua)) return 'mobile';
+    return 'desktop';
+}
+
+function getReferrer(): string {
+    try {
+        const ref = document.referrer;
+        if (!ref) return '';
+        const url = new URL(ref);
+        if (url.hostname === window.location.hostname) return '';
+        return url.hostname;
+    } catch {
+        return '';
+    }
+}
+
+const sent = new Set<string>();
+
+function dedupKey(event: string, route: string): string {
+    return `${event}::${route}`;
+}
+
+export function trackEvent(
+    event: 'view' | 'audio_play' | 'audio_complete' | 'video_play' | 'video_complete',
+    route: string,
+    extra?: { read_seconds?: number; skipDedup?: boolean }
+): void {
+    const key = dedupKey(event, route);
+    if (!extra?.skipDedup && sent.has(key)) return;
+    sent.add(key);
+
+    const payload = JSON.stringify({
+        event,
+        route,
+        session_id: getSessionId(),
+        referrer: getReferrer(),
+        device: getDevice(),
+        read_seconds: extra?.read_seconds ?? 0,
+    });
+
+    if (navigator.sendBeacon) {
+        const blob = new Blob([payload], { type: 'application/json' });
+        navigator.sendBeacon('/api/analytics/event', blob);
+    } else {
+        fetch('/api/analytics/event', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            keepalive: true,
+        }).catch(() => {});
+    }
+}

--- a/src/analytics/usePageTracking.ts
+++ b/src/analytics/usePageTracking.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { trackEvent } from './tracker';
+
+export default function usePageTracking(route: string): void {
+    const startRef = useRef(Date.now());
+
+    useEffect(() => {
+        startRef.current = Date.now();
+        trackEvent('view', route);
+
+        function sendReadTime() {
+            const seconds = Math.round((Date.now() - startRef.current) / 1000);
+            if (seconds > 2) {
+                trackEvent('view', route, { read_seconds: seconds, skipDedup: true });
+            }
+        }
+
+        function onVisibilityChange() {
+            if (document.visibilityState === 'hidden') {
+                sendReadTime();
+            }
+        }
+
+        document.addEventListener('visibilitychange', onVisibilityChange);
+
+        return () => {
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+            sendReadTime();
+        };
+    }, [route]);
+}

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import '../audioplayer.css';
+import { trackEvent } from '../analytics/tracker';
 
 const SPEEDS = [1, 1.25, 1.5, 2];
 
@@ -9,7 +10,7 @@ function formatTime(seconds: number): string {
     return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-function AudioPlayer({ src, title }: { src: string; title: string }) {
+function AudioPlayer({ src, title, route }: { src: string; title: string; route: string }) {
     const audioRef = useRef<HTMLAudioElement>(null);
     const [isPlaying, setIsPlaying] = useState(false);
     const [currentTime, setCurrentTime] = useState(0);
@@ -22,8 +23,8 @@ function AudioPlayer({ src, title }: { src: string; title: string }) {
 
         const onTimeUpdate = () => setCurrentTime(audio.currentTime);
         const onLoadedMetadata = () => setDuration(audio.duration);
-        const onEnded = () => setIsPlaying(false);
-        const onPlay = () => setIsPlaying(true);
+        const onEnded = () => { setIsPlaying(false); trackEvent('audio_complete', route); };
+        const onPlay = () => { setIsPlaying(true); trackEvent('audio_play', route); };
         const onPause = () => setIsPlaying(false);
 
         audio.addEventListener('timeupdate', onTimeUpdate);

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -3,6 +3,7 @@ import { Tags } from '../resources/enums/Tags';
 import ThemeBadge from './ThemeBadge';
 import AudioPlayer from './AudioPlayer';
 import VideoPlayer from './VideoPlayer';
+import usePageTracking from '../analytics/usePageTracking';
 
 function Blog({
     route,
@@ -27,6 +28,8 @@ function Blog({
     audioSrc?: string;
     videoSrc?: string;
 }) {
+    usePageTracking(route);
+
     const img = require(`../articles/pics/${pics[0]}`);
 
     const img2 =
@@ -66,8 +69,8 @@ function Blog({
                     <figcaption className="Caption">{caption}</figcaption>
                 </figure>
             </header>
-            {audioSrc && <AudioPlayer src={audioSrc} title={title} />}
-            {videoSrc && <VideoPlayer src={videoSrc} title={title} />}
+            {audioSrc && <AudioPlayer src={audioSrc} title={title} route={route} />}
+            {videoSrc && <VideoPlayer src={videoSrc} title={title} route={route} />}
             <article className="Content">{content}</article>
             {img2 && (
                 <figure>

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import '../videoplayer.css';
+import { trackEvent } from '../analytics/tracker';
 
 function formatTime(seconds: number): string {
     const m = Math.floor(seconds / 60);
@@ -7,7 +8,7 @@ function formatTime(seconds: number): string {
     return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-function VideoPlayer({ src, title }: { src: string; title: string }) {
+function VideoPlayer({ src, title, route }: { src: string; title: string; route: string }) {
     const videoRef = useRef<HTMLVideoElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -22,8 +23,8 @@ function VideoPlayer({ src, title }: { src: string; title: string }) {
 
         const onTimeUpdate = () => setCurrentTime(video.currentTime);
         const onLoadedMetadata = () => setDuration(video.duration);
-        const onEnded = () => { setIsPlaying(false); setHasStarted(false); };
-        const onPlay = () => { setIsPlaying(true); setHasStarted(true); };
+        const onEnded = () => { setIsPlaying(false); setHasStarted(false); trackEvent('video_complete', route); };
+        const onPlay = () => { setIsPlaying(true); setHasStarted(true); trackEvent('video_play', route); };
         const onPause = () => setIsPlaying(false);
 
         video.addEventListener('timeupdate', onTimeUpdate);

--- a/src/personal/Index.tsx
+++ b/src/personal/Index.tsx
@@ -6,6 +6,7 @@ const TOOLS = [
     { to: '/personal/workout', label: 'Workout Tracker' },
     { to: '/personal/leanlingo', label: 'LeanLingo' },
     { to: '/personal/reflex', label: 'Reflex' },
+    { to: '/personal/analytics', label: 'Analytics' },
 ];
 
 export default function PersonalIndex() {

--- a/src/personal/analytics/Analytics.tsx
+++ b/src/personal/analytics/Analytics.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchAnalyticsSummary, refreshAnalytics, AnalyticsSummary } from './api';
+import '../personal.css';
+import './analytics.css';
+
+function formatReadTime(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+function pct(num: number, denom: number): string {
+    if (denom === 0) return '—';
+    return `${Math.round((num / denom) * 100)}%`;
+}
+
+export default function Analytics() {
+    const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError('');
+        try {
+            const data = await fetchAnalyticsSummary();
+            setSummary(data);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { load(); }, [load]);
+
+    async function onRefresh() {
+        await refreshAnalytics();
+        load();
+    }
+
+    if (loading && !summary) {
+        return <p className="personal-loading">Loading analytics…</p>;
+    }
+
+    return (
+        <div className="personal-page">
+            <Link to="/personal" className="personal-back">&larr; Back</Link>
+            <div className="personal-page-header">
+                <h2>Analytics</h2>
+                <div className="analytics-actions">
+                    <button className="personal-btn" onClick={onRefresh} disabled={loading}>
+                        {loading ? 'Refreshing…' : 'Refresh'}
+                    </button>
+                </div>
+            </div>
+
+            {error && <p className="personal-error">{error}</p>}
+
+            {summary && (
+                <>
+                    <div className="analytics-cards">
+                        <div className="analytics-card">
+                            <div className="analytics-card-value">{summary.totalViews}</div>
+                            <div className="analytics-card-label">Total Views</div>
+                        </div>
+                        <div className="analytics-card">
+                            <div className="analytics-card-value">{summary.uniqueSessions}</div>
+                            <div className="analytics-card-label">Unique Sessions</div>
+                        </div>
+                        <div className="analytics-card">
+                            <div className="analytics-card-value">{summary.totalAudioPlays}</div>
+                            <div className="analytics-card-label">Audio Plays</div>
+                        </div>
+                        <div className="analytics-card">
+                            <div className="analytics-card-value">{summary.totalVideoPlays}</div>
+                            <div className="analytics-card-label">Video Plays</div>
+                        </div>
+                    </div>
+
+                    <div className="analytics-section">
+                        <h3>Per Article</h3>
+                        <div className="analytics-table-wrap">
+                            <table className="analytics-table">
+                                <thead>
+                                    <tr>
+                                        <th>Article</th>
+                                        <th>Views</th>
+                                        <th>Unique</th>
+                                        <th>Listens</th>
+                                        <th>Listen %</th>
+                                        <th>Watches</th>
+                                        <th>Watch %</th>
+                                        <th>Avg Read</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {summary.articles.map((a) => (
+                                        <tr key={a.route}>
+                                            <td>{a.route}</td>
+                                            <td>{a.views}</td>
+                                            <td>{a.uniqueSessions}</td>
+                                            <td>{a.audioPlays}</td>
+                                            <td>{pct(a.audioCompletes, a.audioPlays)}</td>
+                                            <td>{a.videoPlays}</td>
+                                            <td>{pct(a.videoCompletes, a.videoPlays)}</td>
+                                            <td>{formatReadTime(a.avgReadSeconds)}</td>
+                                        </tr>
+                                    ))}
+                                    {summary.articles.length === 0 && (
+                                        <tr>
+                                            <td colSpan={8} style={{ textAlign: 'center', color: 'var(--text-muted)' }}>
+                                                No data yet
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    {summary.topReferrers.length > 0 && (
+                        <div className="analytics-section">
+                            <h3>Top Referrers</h3>
+                            <ul className="analytics-referrers">
+                                {summary.topReferrers.map((r) => (
+                                    <li key={r.referrer}>
+                                        <span>{r.referrer}</span>
+                                        <span>{r.count}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {summary.devices.length > 0 && (
+                        <div className="analytics-section">
+                            <h3>Devices</h3>
+                            <div className="analytics-devices">
+                                {summary.devices.map((d) => (
+                                    <span key={d.device} className="analytics-device">
+                                        {d.device}{' '}
+                                        <span className="analytics-device-pct">{d.percent}%</span>
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/personal/analytics/analytics.css
+++ b/src/personal/analytics/analytics.css
@@ -1,0 +1,129 @@
+.analytics-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+}
+
+.analytics-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+}
+
+.analytics-card-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--text-bright, var(--text));
+    font-variant-numeric: tabular-nums;
+}
+
+.analytics-card-label {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+    letter-spacing: 0.03em;
+}
+
+.analytics-section {
+    margin-bottom: 2rem;
+}
+
+.analytics-section h3 {
+    font-size: 1rem;
+    margin: 0 0 0.75rem;
+    color: var(--text-bright, var(--text));
+}
+
+.analytics-table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.analytics-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.analytics-table th,
+.analytics-table td {
+    padding: 0.5rem 0.65rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+}
+
+.analytics-table th {
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.analytics-table td {
+    color: var(--text);
+}
+
+.analytics-table tr:last-child td {
+    border-bottom: none;
+}
+
+.analytics-referrers {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.analytics-referrers li {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+    color: var(--text);
+}
+
+.analytics-referrers li:last-child {
+    border-bottom: none;
+}
+
+.analytics-devices {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.analytics-device {
+    font-size: 0.9rem;
+    color: var(--text);
+}
+
+.analytics-device-pct {
+    font-weight: 600;
+    color: var(--text-bright, var(--text));
+}
+
+.analytics-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+@media only screen and (max-width: 600px) {
+    .analytics-cards {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .analytics-table {
+        font-size: 0.78rem;
+    }
+
+    .analytics-table th,
+    .analytics-table td {
+        padding: 0.4rem 0.5rem;
+    }
+}

--- a/src/personal/analytics/api.ts
+++ b/src/personal/analytics/api.ts
@@ -1,0 +1,37 @@
+export interface ArticleStats {
+    route: string;
+    views: number;
+    uniqueSessions: number;
+    audioPlays: number;
+    audioCompletes: number;
+    videoPlays: number;
+    videoCompletes: number;
+    avgReadSeconds: number;
+}
+
+export interface AnalyticsSummary {
+    totalViews: number;
+    uniqueSessions: number;
+    totalAudioPlays: number;
+    totalVideoPlays: number;
+    articles: ArticleStats[];
+    topReferrers: { referrer: string; count: number }[];
+    devices: { device: string; count: number; percent: number }[];
+}
+
+export async function fetchAnalyticsSummary(): Promise<AnalyticsSummary> {
+    const res = await fetch('/api/personal/analytics/summary', {
+        credentials: 'same-origin',
+    });
+    if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+    }
+    return res.json();
+}
+
+export async function refreshAnalytics(): Promise<void> {
+    await fetch('/api/personal/analytics/refresh', {
+        method: 'POST',
+        credentials: 'same-origin',
+    });
+}


### PR DESCRIPTION
## Summary

- Track visitor engagement (page views, audio/video plays & completions, read time, referrers, device type) across all articles — fires automatically, no per-article wiring needed
- Buffer events server-side in memory, flush to Excel via Graph API every 2 minutes or at 50 events
- Add authenticated dashboard at `/personal/analytics` with summary cards, per-article stats table, top referrers, and device breakdown
- Document the analytics architecture in CLAUDE.md for future sessions

## Details

**Server (4 new files):**
- `server/analytics/excel.ts` — Graph API read/write for `/PersonalApps/blog-analytics.xlsx`
- `server/analytics/buffer.ts` — In-memory event buffer with timed flush
- `server/analytics/cache.ts` — 5-min TTL aggregation cache for dashboard reads
- `server/routes/analytics.ts` — Public `POST /api/analytics/event` (rate-limited 30 req/min/IP) + auth'd summary/refresh endpoints

**Client tracking (2 new files):**
- `src/analytics/tracker.ts` — `trackEvent()` via `sendBeacon`, session UUID in `sessionStorage`, per-session dedup
- `src/analytics/usePageTracking.ts` — Hook for view tracking + read time on unmount/tab switch

**Dashboard (3 new files):**
- `src/personal/analytics/Analytics.tsx` — Summary cards + per-article table + referrers + devices
- `src/personal/analytics/analytics.css` — Responsive dashboard styles
- `src/personal/analytics/api.ts` — Fetch helpers

**Modified files:**
- `server/index.ts` — Mount analytics routes, start flusher
- `src/components/Blog.tsx` — Call `usePageTracking(route)`
- `src/components/AudioPlayer.tsx` — Add `route` prop, track `audio_play`/`audio_complete`
- `src/components/VideoPlayer.tsx` — Add `route` prop, track `video_play`/`video_complete`
- `src/personal/Index.tsx` — Add Analytics link to tools list
- `src/App.tsx` — Add `/personal/analytics` route

Zero new npm dependencies — rate limiter is a simple in-memory Map. No cookies or fingerprinting.

## Manual setup before deploying

Create `/PersonalApps/blog-analytics.xlsx` in OneDrive with a table named `Events` and columns: `timestamp`, `session_id`, `event`, `route`, `referrer`, `device`, `read_seconds`.

## Test plan

- [ ] Visit an article — verify `POST /api/analytics/event` fires with `view` event (Network tab)
- [ ] Play audio — `audio_play` event fires; let it finish — `audio_complete` fires
- [ ] Play video — same pattern
- [ ] Navigate away or switch tab — `read_seconds` sent via sendBeacon
- [ ] Wait 2 minutes — server flushes buffer to Excel (check server console)
- [ ] Log in to `/personal/analytics` — dashboard shows aggregated stats
- [ ] Rapid-fire >30 requests in 1 minute — returns 429
- [ ] Check Excel workbook in OneDrive — rows appear in the Events table
- [ ] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6HGxS3ukjfbWjrsqG8fai

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6HGxS3ukjfbWjrsqG8fai)_