### PR TITLE
Clean up article pages: remove Curry-Howard line, hide AI Engineering media, move tags next to date

### DIFF
--- a/src/articles/AiEngineering.tsx
+++ b/src/articles/AiEngineering.tsx
@@ -183,8 +183,6 @@ const AiEngineering: ArticleProps = {
         'Building deterministic and stochastic software with LangChain, LangGraph, and Ollama.',
     createdDate: '2026-03-28',
     tags: [Tags.Computation],
-    audioSrc: '/audio/ai-engineering.m4a',
-    videoSrc: 'https://kennethjusinoblog.blob.core.windows.net/videos/img-1710.mov',
     content: [
         <h2>Deterministic vs Stochastic Software</h2>,
         <p>

--- a/src/articles/LeanInToGradSchool.tsx
+++ b/src/articles/LeanInToGradSchool.tsx
@@ -314,8 +314,8 @@ const LeanInToGradSchool: ArticleProps = {
         <p>
             The <code>→</code> symbol means "function" and "implies"
             simultaneously. These aren't analogies, they are the same thing.
-            That's Curry-Howard. And that's why the future of software
-            engineering is verifying mathematical proofs.
+            And that's why the future of software engineering is verifying
+            mathematical proofs.
         </p>,
         <p>
             The futures of AI, Mathematics, and Computer Science are intricately

--- a/src/blog.css
+++ b/src/blog.css
@@ -69,17 +69,41 @@
     margin-top: 0.6rem;
 }
 
-/* Publication date */
+/* Publication meta — date + tags row */
+.blog-page .publish-meta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-top: 0.8rem;
+}
+
 .blog-page .publish-date {
-    display: block;
     font-size: 0.78rem;
     font-weight: 500;
     color: var(--text-dim);
     letter-spacing: 0.04em;
-    margin-top: 0.8rem;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
         'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
         'Helvetica Neue', sans-serif;
+}
+
+.blog-page .ThemeTags {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+        'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+        'Helvetica Neue', sans-serif;
+}
+
+.blog-page .ThemeTags::before {
+    content: '\00b7';
+    color: var(--text-dim);
 }
 
 /* Section headings within articles */

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -53,20 +53,6 @@ function Blog({
         <div className={articleClass}>
             <header className="Article-header">
                 <h1>{title}</h1>
-                {tags && tags.length > 0 && (
-                    <div
-                        className="ThemeTags"
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            gap: 8,
-                        }}
-                    >
-                        <ThemeBadge tags={tags} size={18} />
-                        <span>{tags.join(' · ')}</span>
-                    </div>
-                )}
                 <em className="Abstract">{abstract}</em>
                 <figure>
                     <a
@@ -81,9 +67,17 @@ function Blog({
                     <figcaption className="Caption">{caption}</figcaption>
                 </figure>
                 {isBlogPost && createdDate && (
-                    <time className="publish-date" dateTime={createdDate}>
-                        {formatDate(createdDate)}
-                    </time>
+                    <div className="publish-meta">
+                        <time className="publish-date" dateTime={createdDate}>
+                            {formatDate(createdDate)}
+                        </time>
+                        {tags && tags.length > 0 && (
+                            <div className="ThemeTags">
+                                <ThemeBadge tags={tags} size={14} />
+                                <span>{tags.join(' · ')}</span>
+                            </div>
+                        )}
+                    </div>
                 )}
             </header>
             {audioSrc && <AudioPlayer src={audioSrc} title={title} route={route} />}


### PR DESCRIPTION
- Remove "That's Curry-Howard." sentence from Lean article
- Remove audioSrc and videoSrc from AI Engineering article until real content is recorded
- Move article tags from between title and image to inline with the publication date below the caption

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GrVxX9kMhtyTSjqiRHwJ4M