### PR TITLE
Add Projects page and remove LeanLingo from personal section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Blogs from './components/Blogs';
 import PersonalLayout from './personal/PersonalLayout';
 import PersonalIndex from './personal/Index';
 import Workout from './personal/workout/Workout';
-import LeanLingo from './personal/leanlingo/LeanLingo';
+import Projects from './components/Projects';
 import Reflex from './personal/reflex/Reflex';
 import Analytics from './personal/analytics/Analytics';
 
@@ -37,6 +37,7 @@ function App() {
     }
     routes.push(<Route key="articles" path="articles" element={<Articles />} />);
     routes.push(<Route key="blogs" path="blogs" element={<Blogs />} />);
+    routes.push(<Route key="projects" path="projects" element={<Projects />} />);
     return (
         <header className="App-header">
             <BrowserRouter>
@@ -46,7 +47,6 @@ function App() {
                     <Route path="/personal" element={<PersonalLayout />}>
                         <Route index element={<PersonalIndex />} />
                         <Route path="workout" element={<Workout />} />
-                        <Route path="leanlingo" element={<LeanLingo />} />
                         <Route path="reflex" element={<Reflex />} />
                         <Route path="analytics" element={<Analytics />} />
                     </Route>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -32,6 +32,9 @@ const NavBar = () => {
                     <a href="/blogs" onClick={closeMenu}>
                         Blogs
                     </a>
+                    <a href="/projects" onClick={closeMenu}>
+                        Projects
+                    </a>
                     <a href="/cv" onClick={closeMenu}>
                         CV
                     </a>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,45 @@
+import '../projects.css';
+
+interface Project {
+    name: string;
+    description: string;
+    url: string;
+    displayUrl: string;
+}
+
+const PROJECTS: Project[] = [
+    {
+        name: 'LeanLingo',
+        description:
+            'A Duolingo-style interactive learning platform for Lean 4, the programming language and theorem prover. Practice formal verification through bite-sized lessons.',
+        url: 'https://leanlingo.org',
+        displayUrl: 'leanlingo.org',
+    },
+];
+
+const Projects = () => (
+    <div className="projects-page">
+        <div className="projects-header">
+            <div className="projects-header-label">Portfolio</div>
+            <h1>Projects</h1>
+            <p>Things I've built and made accessible for all.</p>
+        </div>
+        <div className="projects-grid">
+            {PROJECTS.map((p) => (
+                <a
+                    key={p.url}
+                    className="project-card"
+                    href={p.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <h2 className="project-card-name">{p.name}</h2>
+                    <p className="project-card-desc">{p.description}</p>
+                    <span className="project-card-url">{p.displayUrl} &rarr;</span>
+                </a>
+            ))}
+        </div>
+    </div>
+);
+
+export default Projects;

--- a/src/personal/Index.tsx
+++ b/src/personal/Index.tsx
@@ -4,7 +4,6 @@ import './personal.css';
 
 const TOOLS = [
     { to: '/personal/workout', label: 'Workout Tracker' },
-    { to: '/personal/leanlingo', label: 'LeanLingo' },
     { to: '/personal/reflex', label: 'Reflex' },
     { to: '/personal/analytics', label: 'Analytics' },
 ];

--- a/src/projects.css
+++ b/src/projects.css
@@ -1,0 +1,93 @@
+.projects-page {
+    width: 100%;
+    max-width: 900px;
+    margin: 3rem auto;
+    padding: 0 2rem;
+    box-sizing: border-box;
+    text-align: left;
+}
+
+.projects-header {
+    margin-bottom: 2.5rem;
+}
+
+.projects-header-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 8px;
+}
+
+.projects-header h1 {
+    margin: 0;
+    font-size: 26px;
+    font-weight: 700;
+    color: var(--text-bright);
+    letter-spacing: -0.02em;
+}
+
+.projects-header p {
+    margin: 7px 0 0;
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.25rem;
+}
+
+.project-card {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.5rem;
+    text-decoration: none;
+    color: var(--text);
+    transition:
+        border-color 0.2s,
+        transform 0.15s;
+}
+
+.project-card:hover {
+    border-color: var(--accent);
+    color: var(--text);
+    transform: translateY(-2px);
+}
+
+.project-card-name {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    margin: 0 0 0.5rem;
+}
+
+.project-card-desc {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin: 0 0 1rem;
+    flex: 1;
+}
+
+.project-card-url {
+    font-size: 0.85rem;
+    color: var(--accent);
+    font-weight: 600;
+}
+
+@media (max-width: 600px) {
+    .projects-page {
+        padding: 0 1.25rem;
+        margin: 2rem auto;
+    }
+
+    .projects-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
LeanLingo has its own site at leanlingo.org — replace the in-app
version with a project card linking to the official site. Adds a
"Projects" nav item between Blogs and CV.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YaCZWNfTCUzUNaLZFybdko