### PR TITLE
Add LeanLingo OG image to project card

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -5,6 +5,7 @@ interface Project {
     description: string;
     url: string;
     displayUrl: string;
+    image?: string;
 }
 
 const PROJECTS: Project[] = [
@@ -14,6 +15,7 @@ const PROJECTS: Project[] = [
             'A Duolingo-style interactive learning platform for Lean 4, the programming language and theorem prover. Practice formal verification through bite-sized lessons.',
         url: 'https://leanlingo.org',
         displayUrl: 'leanlingo.org',
+        image: 'https://leanlingo.org/og.png',
     },
 ];
 
@@ -33,9 +35,20 @@ const Projects = () => (
                     target="_blank"
                     rel="noopener noreferrer"
                 >
-                    <h2 className="project-card-name">{p.name}</h2>
-                    <p className="project-card-desc">{p.description}</p>
-                    <span className="project-card-url">{p.displayUrl} &rarr;</span>
+                    {p.image && (
+                        <img
+                            className="project-card-img"
+                            src={p.image}
+                            alt={p.name}
+                        />
+                    )}
+                    <div className="project-card-body">
+                        <h2 className="project-card-name">{p.name}</h2>
+                        <p className="project-card-desc">{p.description}</p>
+                        <span className="project-card-url">
+                            {p.displayUrl} &rarr;
+                        </span>
+                    </div>
                 </a>
             ))}
         </div>

--- a/src/projects.css
+++ b/src/projects.css
@@ -46,7 +46,7 @@
     background-color: var(--card-bg);
     border: 1px solid var(--border);
     border-radius: 10px;
-    padding: 1.5rem;
+    overflow: hidden;
     text-decoration: none;
     color: var(--text);
     transition:
@@ -58,6 +58,19 @@
     border-color: var(--accent);
     color: var(--text);
     transform: translateY(-2px);
+}
+
+.project-card-img {
+    width: 100%;
+    display: block;
+    object-fit: cover;
+}
+
+.project-card-body {
+    padding: 1.25rem 1.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 .project-card-name {


### PR DESCRIPTION
## Summary
- Displays the `leanlingo.org/og.png` preview image at the top of the LeanLingo project card — the same branded image that appears in iMessage and social link previews
- Adds `image` field to the `Project` interface for future project cards
- Card layout updated: image spans full width at top, text content padded below

## Test plan
- [ ] Visit `/projects` and verify the LeanLingo OG image loads at the top of the card
- [ ] Confirm card hover effect (border highlight + lift) still works
- [ ] Check responsive layout on mobile (single column, image scales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaCZWNfTCUzUNaLZFybdko

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaCZWNfTCUzUNaLZFybdko)_