### PR TITLE
Add OG image meta tags for article link previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && tsx scripts/generate-og-data.ts",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "test:e2e": "playwright test",

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#000000" />
         <meta
             name="description"
-            content="Web site created using create-react-app"
+            content="Math, Code, and Culture — by Kenneth Jusino"
         />
         <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
         <!--

--- a/scripts/generate-og-data.ts
+++ b/scripts/generate-og-data.ts
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import path from 'path';
+
+const ARTICLES_DIR = path.resolve(__dirname, '..', 'src', 'articles');
+const PICS_DIR = path.join(ARTICLES_DIR, 'pics');
+const BUILD_DIR = path.resolve(__dirname, '..', 'build');
+const OG_DIR = path.join(BUILD_DIR, 'og');
+
+interface OgEntry {
+    title: string;
+    description: string;
+    image: string;
+}
+
+function extractField(source: string, field: string): string | undefined {
+    // Match field: 'value' or field: "value", handling embedded quotes of the other type
+    const doubleQuoted = new RegExp(`${field}:\\s*"([^"]+)"`);
+    const singleQuoted = new RegExp(`${field}:\\s*'([^']+)'`);
+
+    // Also handle multi-line: field:\n        "value"
+    const doubleMulti = new RegExp(`${field}:\\s*\\n\\s*"([^"]+)"`);
+    const singleMulti = new RegExp(`${field}:\\s*\\n\\s*'([^']+)'`);
+
+    for (const re of [doubleQuoted, singleQuoted, doubleMulti, singleMulti]) {
+        const m = source.match(re);
+        if (m) return m[1];
+    }
+
+    return undefined;
+}
+
+function extractFirstPic(source: string): string | undefined {
+    const m = source.match(/pics:\s*\[['"]([^'"]+)['"]/);
+    return m ? m[1] : undefined;
+}
+
+const allDataSource = fs.readFileSync(path.join(ARTICLES_DIR, 'allData.tsx'), 'utf-8');
+const importMatches = [...allDataSource.matchAll(/import\s+\w+\s+from\s+['"]\.\/([\w]+)['"]/g)];
+const articleFiles = importMatches.map(m => m[1] + '.tsx');
+
+fs.mkdirSync(OG_DIR, { recursive: true });
+
+const manifest: Record<string, OgEntry> = {};
+
+for (const file of articleFiles) {
+    const filePath = path.join(ARTICLES_DIR, file);
+    if (!fs.existsSync(filePath)) continue;
+
+    const source = fs.readFileSync(filePath, 'utf-8');
+
+    let route = extractField(source, 'route');
+    if (!route) continue;
+    if (!route.startsWith('/')) route = '/' + route;
+
+    const title = extractField(source, 'title');
+    if (!title) continue;
+
+    const pic = extractFirstPic(source);
+    if (!pic) continue;
+
+    const description = extractField(source, 'abstract') || extractField(source, 'caption') || title;
+
+    const srcImage = path.join(PICS_DIR, pic);
+    if (!fs.existsSync(srcImage)) {
+        console.warn(`[og] image not found: ${srcImage}, skipping ${route}`);
+        continue;
+    }
+
+    fs.copyFileSync(srcImage, path.join(OG_DIR, pic));
+
+    manifest[route] = {
+        title,
+        description,
+        image: `/og/${pic}`,
+    };
+}
+
+fs.writeFileSync(path.join(BUILD_DIR, 'og-manifest.json'), JSON.stringify(manifest, null, 2));
+console.log(`[og] generated manifest with ${Object.keys(manifest).length} entries`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,12 +2,14 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 import helmet from 'helmet';
 import path from 'path';
+import fs from 'fs';
 import { env } from './env';
 import { authRouter, requireAuth } from './auth';
 import { workoutRouter } from './routes/workout';
 import { leanlingoRouter } from './routes/leanlingo';
 import { analyticsPublicRouter, analyticsPrivateRouter } from './routes/analytics';
 import { startFlusher } from './analytics/buffer';
+import { injectOgTags } from './og';
 
 const app = express();
 
@@ -37,10 +39,13 @@ app.use('/api/personal/analytics', requireAuth, analyticsPrivateRouter);
 startFlusher();
 
 const buildDir = path.resolve(__dirname, '..', 'build');
-app.use(express.static(buildDir));
+app.use(express.static(buildDir, { index: false }));
 
-app.get('*', (_req, res) => {
-    res.sendFile(path.join(buildDir, 'index.html'));
+const indexHtml = fs.readFileSync(path.join(buildDir, 'index.html'), 'utf-8');
+const ogInjector = injectOgTags(buildDir);
+
+app.get('*', (req, res) => {
+    res.type('html').send(ogInjector(indexHtml, req.path));
 });
 
 app.listen(env.PORT, () => {

--- a/server/og.ts
+++ b/server/og.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+interface OgEntry {
+    title: string;
+    description: string;
+    image: string;
+}
+
+const BASE_URL = process.env.BASE_URL || 'https://kennethjusino.com';
+const SITE_NAME = 'Your Fave Place To Learn';
+const HEAD_CLOSE = '</head>';
+
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function injectOgTags(buildDir: string): (html: string, reqPath: string) => string {
+    const manifestPath = path.join(buildDir, 'og-manifest.json');
+    const manifest: Record<string, OgEntry> = fs.existsSync(manifestPath)
+        ? JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+        : {};
+
+    return (html: string, reqPath: string): string => {
+        const entry = manifest[reqPath];
+
+        const title = entry?.title || SITE_NAME;
+        const description = entry?.description || 'Math, Code, and Culture — by Kenneth Jusino';
+        const url = `${BASE_URL}${reqPath}`;
+        const ogType = entry && reqPath !== '/' ? 'article' : 'website';
+
+        const tags = [
+            `<meta property="og:type" content="${ogType}" />`,
+            `<meta property="og:title" content="${escapeAttr(title)}" />`,
+            `<meta property="og:description" content="${escapeAttr(description)}" />`,
+            `<meta property="og:url" content="${escapeAttr(url)}" />`,
+            `<meta property="og:site_name" content="${escapeAttr(SITE_NAME)}" />`,
+        ];
+
+        if (entry) {
+            const imageUrl = `${BASE_URL}${entry.image}`;
+            tags.push(`<meta property="og:image" content="${escapeAttr(imageUrl)}" />`);
+            tags.push(`<meta name="twitter:card" content="summary_large_image" />`);
+            tags.push(`<meta name="twitter:title" content="${escapeAttr(title)}" />`);
+            tags.push(`<meta name="twitter:description" content="${escapeAttr(description)}" />`);
+            tags.push(`<meta name="twitter:image" content="${escapeAttr(imageUrl)}" />`);
+        }
+
+        return html.replace(HEAD_CLOSE, tags.join('') + HEAD_CLOSE);
+    };
+}


### PR DESCRIPTION
Social media crawlers don't execute JavaScript, so the Express server now
injects per-article Open Graph and Twitter Card meta tags into index.html
before serving it. A build-time script extracts article metadata (title,
description, hero image) and copies hero images to build/og/ with stable
URLs.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EjazyK9LLbtrT4uFHHn9fZ