### PR TITLE
Add Calibrate: a personal forecasting-calibration tracker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Workout from './personal/workout/Workout';
 import Projects from './components/Projects';
 import Reflex from './personal/reflex/Reflex';
 import Analytics from './personal/analytics/Analytics';
+import Calibrate from './personal/calibrate/Calibrate';
 
 const NON_BLOG_ROUTES = new Set(['/', '/cv', '/personal']);
 
@@ -49,6 +50,7 @@ function App() {
                         <Route path="workout" element={<Workout />} />
                         <Route path="reflex" element={<Reflex />} />
                         <Route path="analytics" element={<Analytics />} />
+                        <Route path="calibrate" element={<Calibrate />} />
                     </Route>
                 </Routes>
             </BrowserRouter>

--- a/src/personal/Index.tsx
+++ b/src/personal/Index.tsx
@@ -6,6 +6,7 @@ const TOOLS = [
     { to: '/personal/workout', label: 'Workout Tracker' },
     { to: '/personal/reflex', label: 'Reflex' },
     { to: '/personal/analytics', label: 'Analytics' },
+    { to: '/personal/calibrate', label: 'Calibrate' },
 ];
 
 export default function PersonalIndex() {

--- a/src/personal/calibrate/Calibrate.tsx
+++ b/src/personal/calibrate/Calibrate.tsx
@@ -1,0 +1,293 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import './calibrate.css';
+
+type Status = 'pending' | 'true' | 'false';
+
+type Prediction = {
+    id: string;
+    text: string;
+    confidence: number; // 50-99, stated probability the statement resolves true
+    createdAt: number;
+    resolveBy: string | null; // yyyy-mm-dd
+    status: Status;
+    resolvedAt: number | null;
+};
+
+const KEY = 'personal:calibrate:v1';
+const BUCKETS: [number, number][] = [
+    [50, 60],
+    [60, 70],
+    [70, 80],
+    [80, 90],
+    [90, 100],
+];
+
+function uid(): string {
+    return `${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+}
+
+function load(): Prediction[] {
+    try {
+        const raw = localStorage.getItem(KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.slice(-500) : [];
+    } catch {
+        return [];
+    }
+}
+
+function save(predictions: Prediction[]): void {
+    try {
+        localStorage.setItem(KEY, JSON.stringify(predictions.slice(-500)));
+    } catch {
+        /* localStorage full or denied — non-fatal */
+    }
+}
+
+function todayStr(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+function brierLabel(score: number): string {
+    if (score < 0.1) return 'excellent calibration';
+    if (score < 0.18) return 'well calibrated';
+    if (score < 0.25) return 'room to tighten up';
+    return 'overconfident or underconfident';
+}
+
+export default function Calibrate() {
+    const [predictions, setPredictions] = useState<Prediction[]>(() => load());
+    const [text, setText] = useState('');
+    const [confidence, setConfidence] = useState(70);
+    const [resolveBy, setResolveBy] = useState('');
+
+    function persist(next: Prediction[]) {
+        setPredictions(next);
+        save(next);
+    }
+
+    function addPrediction() {
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        const p: Prediction = {
+            id: uid(),
+            text: trimmed,
+            confidence,
+            createdAt: Date.now(),
+            resolveBy: resolveBy || null,
+            status: 'pending',
+            resolvedAt: null,
+        };
+        persist([...predictions, p]);
+        setText('');
+        setResolveBy('');
+        setConfidence(70);
+    }
+
+    function resolve(id: string, outcome: 'true' | 'false') {
+        persist(
+            predictions.map((p) =>
+                p.id === id ? { ...p, status: outcome, resolvedAt: Date.now() } : p
+            )
+        );
+    }
+
+    function remove(id: string) {
+        persist(predictions.filter((p) => p.id !== id));
+    }
+
+    const pending = useMemo(
+        () => predictions.filter((p) => p.status === 'pending').sort((a, b) => a.createdAt - b.createdAt),
+        [predictions]
+    );
+    const resolved = useMemo(
+        () => predictions.filter((p) => p.status !== 'pending').sort((a, b) => (b.resolvedAt ?? 0) - (a.resolvedAt ?? 0)),
+        [predictions]
+    );
+
+    const brier = useMemo(() => {
+        if (resolved.length === 0) return null;
+        const sum = resolved.reduce((acc, p) => {
+            const outcome = p.status === 'true' ? 1 : 0;
+            const c = p.confidence / 100;
+            return acc + (c - outcome) ** 2;
+        }, 0);
+        return sum / resolved.length;
+    }, [resolved]);
+
+    const buckets = useMemo(() => {
+        return BUCKETS.map(([lo, hi]) => {
+            const inBucket = resolved.filter((p) => p.confidence >= lo && p.confidence < hi + (hi === 100 ? 1 : 0));
+            if (inBucket.length === 0) return { lo, hi, count: 0, avgConfidence: 0, actualRate: 0 };
+            const avgConfidence = inBucket.reduce((s, p) => s + p.confidence, 0) / inBucket.length;
+            const actualRate =
+                (inBucket.filter((p) => p.status === 'true').length / inBucket.length) * 100;
+            return { lo, hi, count: inBucket.length, avgConfidence, actualRate };
+        });
+    }, [resolved]);
+
+    const today = todayStr();
+
+    return (
+        <div className="calib">
+            <div className="calib-header">
+                <Link to="/personal" className="calib-back">← personal</Link>
+                <span className="calib-title">Calibrate</span>
+                <span className="calib-brier">
+                    {brier !== null ? `brier ${brier.toFixed(3)}` : 'no data yet'}
+                </span>
+            </div>
+
+            <div className="calib-intro">
+                Log a prediction with your honest confidence (50–99%). Resolve it later.
+                Over time this shows whether your gut feel matches reality — the core
+                skill behind every good bet, forecast, and business decision.
+            </div>
+
+            <div className="calib-form">
+                <textarea
+                    className="calib-input"
+                    placeholder="What are you predicting? e.g. 'This feature ships by Friday'"
+                    value={text}
+                    onChange={(e) => setText(e.target.value)}
+                    rows={2}
+                />
+                <div className="calib-form-row">
+                    <label className="calib-confidence-label">
+                        confidence
+                        <input
+                            type="range"
+                            min={50}
+                            max={99}
+                            value={confidence}
+                            onChange={(e) => setConfidence(Number(e.target.value))}
+                        />
+                        <span className="calib-confidence-value">{confidence}%</span>
+                    </label>
+                    <input
+                        type="date"
+                        className="calib-date-input"
+                        value={resolveBy}
+                        min={today}
+                        onChange={(e) => setResolveBy(e.target.value)}
+                    />
+                </div>
+                <button type="button" className="calib-btn calib-btn-primary" onClick={addPrediction}>
+                    Log prediction
+                </button>
+            </div>
+
+            {pending.length > 0 && (
+                <div className="calib-section">
+                    <div className="calib-section-title">Pending ({pending.length})</div>
+                    <ul className="calib-list">
+                        {pending.map((p) => {
+                            const overdue = p.resolveBy !== null && p.resolveBy < today;
+                            return (
+                                <li key={p.id} className={`calib-item${overdue ? ' calib-item-overdue' : ''}`}>
+                                    <div className="calib-item-main">
+                                        <span className="calib-item-text">{p.text}</span>
+                                        <span className="calib-item-conf">{p.confidence}%</span>
+                                    </div>
+                                    <div className="calib-item-meta">
+                                        {p.resolveBy && (
+                                            <span className={overdue ? 'calib-overdue-tag' : ''}>
+                                                {overdue ? 'overdue since' : 'check by'} {p.resolveBy}
+                                            </span>
+                                        )}
+                                        <div className="calib-item-actions">
+                                            <button type="button" className="calib-chip calib-chip-true" onClick={() => resolve(p.id, 'true')}>
+                                                ✓ true
+                                            </button>
+                                            <button type="button" className="calib-chip calib-chip-false" onClick={() => resolve(p.id, 'false')}>
+                                                ✗ false
+                                            </button>
+                                            <button type="button" className="calib-chip" onClick={() => remove(p.id)}>
+                                                remove
+                                            </button>
+                                        </div>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            )}
+
+            {resolved.length > 0 && (
+                <>
+                    <div className="calib-section">
+                        <div className="calib-section-title">Calibration by confidence</div>
+                        <div className="calib-buckets">
+                            {buckets.map((b) => (
+                                <div key={b.lo} className="calib-bucket">
+                                    <span className="calib-bucket-range">{b.lo}-{b.hi}%</span>
+                                    <div className="calib-bucket-bar-track">
+                                        <div
+                                            className="calib-bucket-bar-predicted"
+                                            style={{ width: `${b.count ? (b.lo + b.hi) / 2 : 0}%` }}
+                                        />
+                                        <div
+                                            className="calib-bucket-bar-actual"
+                                            style={{ width: `${b.actualRate}%` }}
+                                        />
+                                    </div>
+                                    <span className="calib-bucket-count">
+                                        {b.count > 0 ? `${Math.round(b.actualRate)}% actual (n=${b.count})` : 'n=0'}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="calib-bucket-legend">
+                            <span><i className="calib-swatch calib-swatch-predicted" /> stated confidence</span>
+                            <span><i className="calib-swatch calib-swatch-actual" /> actual outcome rate</span>
+                        </div>
+                    </div>
+
+                    {brier !== null && (
+                        <div className="calib-stats">
+                            <div className="calib-stat">
+                                <span className="calib-stat-label">brier score</span>
+                                <span className="calib-stat-value">{brier.toFixed(3)}</span>
+                            </div>
+                            <div className="calib-stat">
+                                <span className="calib-stat-label">resolved</span>
+                                <span className="calib-stat-value">{resolved.length}</span>
+                            </div>
+                            <div className="calib-stat">
+                                <span className="calib-stat-label">read</span>
+                                <span className="calib-stat-value calib-stat-value-text">{brierLabel(brier)}</span>
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="calib-section">
+                        <div className="calib-section-title">History</div>
+                        <ul className="calib-list">
+                            {resolved.slice(0, 20).map((p) => (
+                                <li key={p.id} className="calib-item calib-item-resolved">
+                                    <div className="calib-item-main">
+                                        <span className="calib-item-text">{p.text}</span>
+                                        <span className="calib-item-conf">{p.confidence}%</span>
+                                    </div>
+                                    <span className={`calib-outcome-tag calib-outcome-${p.status}`}>
+                                        {p.status === 'true' ? 'happened' : "didn't happen"}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </>
+            )}
+
+            {predictions.length === 0 && (
+                <div className="calib-empty">
+                    No predictions yet. Log your first one above — confidence should reflect
+                    what you'd bet real money on, not what you want to be true.
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/personal/calibrate/calibrate.css
+++ b/src/personal/calibrate/calibrate.css
@@ -1,0 +1,295 @@
+.calib {
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 16px;
+    color: #e5e7eb;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.calib-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 12px;
+    font-size: 13px;
+}
+.calib-back {
+    color: #94a3b8;
+    text-decoration: none;
+    padding: 8px 4px;
+}
+.calib-back:hover { color: #e5e7eb; }
+.calib-title {
+    font-weight: 600;
+    color: #e5e7eb;
+    letter-spacing: 0.4px;
+}
+.calib-brier {
+    color: #fbbf24;
+    font-family: 'JetBrains Mono', 'Menlo', monospace;
+    font-size: 12px;
+}
+
+.calib-intro {
+    font-size: 13px;
+    color: #94a3b8;
+    line-height: 1.5;
+    margin-bottom: 16px;
+}
+
+.calib-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 14px;
+    padding: 14px;
+    margin-bottom: 18px;
+}
+.calib-input {
+    width: 100%;
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 10px;
+    color: #e5e7eb;
+    padding: 10px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    resize: vertical;
+    box-sizing: border-box;
+}
+.calib-form-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.calib-confidence-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: #94a3b8;
+    flex: 1;
+    min-width: 180px;
+}
+.calib-confidence-label input[type='range'] {
+    flex: 1;
+    accent-color: #0ea5e9;
+}
+.calib-confidence-value {
+    font-family: 'JetBrains Mono', 'Menlo', monospace;
+    color: #e5e7eb;
+    min-width: 34px;
+    text-align: right;
+}
+.calib-date-input {
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    color: #e5e7eb;
+    padding: 6px 8px;
+    font-size: 12px;
+    font-family: inherit;
+}
+
+.calib-btn {
+    background: #1e293b;
+    color: #e5e7eb;
+    border: 1px solid #334155;
+    border-radius: 10px;
+    padding: 12px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+}
+.calib-btn-primary {
+    background: #0ea5e9;
+    border-color: #0ea5e9;
+    color: white;
+}
+.calib-btn-primary:hover { background: #0284c7; }
+
+.calib-section { margin-top: 20px; }
+.calib-section-title {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #64748b;
+    margin-bottom: 8px;
+}
+
+.calib-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.calib-item {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+.calib-item-overdue { border-color: #b91c1c; }
+.calib-item-main {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    align-items: baseline;
+}
+.calib-item-text {
+    font-size: 14px;
+    color: #e5e7eb;
+    line-height: 1.4;
+}
+.calib-item-conf {
+    font-family: 'JetBrains Mono', 'Menlo', monospace;
+    color: #fbbf24;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.calib-item-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    font-size: 11px;
+    color: #64748b;
+    flex-wrap: wrap;
+}
+.calib-overdue-tag { color: #f87171; }
+.calib-item-actions {
+    display: flex;
+    gap: 6px;
+    margin-left: auto;
+}
+.calib-chip {
+    background: #1e293b;
+    border: 1px solid #334155;
+    color: #cbd5e1;
+    border-radius: 999px;
+    padding: 5px 10px;
+    font-size: 11px;
+    cursor: pointer;
+    font-family: inherit;
+}
+.calib-chip-true { border-color: #16a34a; color: #86efac; }
+.calib-chip-true:hover { background: #14532d; }
+.calib-chip-false { border-color: #b91c1c; color: #fca5a5; }
+.calib-chip-false:hover { background: #7f1d1d; }
+
+.calib-item-resolved { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+.calib-item-resolved .calib-item-main { flex: 1; }
+.calib-outcome-tag {
+    font-size: 11px;
+    border-radius: 999px;
+    padding: 4px 10px;
+    white-space: nowrap;
+}
+.calib-outcome-true { background: #14532d; color: #86efac; }
+.calib-outcome-false { background: #57534e; color: #d6d3d1; }
+
+.calib-buckets {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.calib-bucket {
+    display: grid;
+    grid-template-columns: 56px 1fr 140px;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+}
+.calib-bucket-range {
+    font-family: 'JetBrains Mono', 'Menlo', monospace;
+    color: #94a3b8;
+}
+.calib-bucket-bar-track {
+    position: relative;
+    height: 10px;
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 6px;
+    overflow: hidden;
+}
+.calib-bucket-bar-predicted {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: #334155;
+}
+.calib-bucket-bar-actual {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 4px;
+    bottom: 0;
+    margin: auto 0;
+    background: #0ea5e9;
+    border-radius: 4px;
+}
+.calib-bucket-count { color: #64748b; text-align: right; }
+.calib-bucket-legend {
+    display: flex;
+    gap: 16px;
+    margin-top: 8px;
+    font-size: 11px;
+    color: #64748b;
+}
+.calib-bucket-legend span { display: flex; align-items: center; gap: 6px; }
+.calib-swatch { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
+.calib-swatch-predicted { background: #334155; }
+.calib-swatch-actual { background: #0ea5e9; }
+
+.calib-stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-top: 18px;
+}
+.calib-stat {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 10px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: center;
+    text-align: center;
+}
+.calib-stat-label {
+    font-size: 11px;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.calib-stat-value {
+    font-size: 16px;
+    font-weight: 600;
+    color: #e5e7eb;
+    font-family: 'JetBrains Mono', 'Menlo', monospace;
+}
+.calib-stat-value-text {
+    font-size: 12px;
+    font-family: inherit;
+    font-weight: 500;
+    color: #cbd5e1;
+}
+
+.calib-empty {
+    margin-top: 12px;
+    font-size: 13px;
+    color: #64748b;
+    text-align: center;
+    line-height: 1.5;
+}


### PR DESCRIPTION
Log predictions with a stated confidence (50-99%), resolve them true/false
later, and see a Brier score plus a bucketed calibration chart comparing
stated confidence to actual outcome rate. Client-only (localStorage),
matching the Reflex tool's pattern. Distinct from existing personal tools:
Workout is fitness, Reflex is reaction time, Analytics is blog stats —
this one trains judgment/decision calibration, a skill with direct
professional and financial payoff.