### PR TITLE
Add "Keep reading" related-articles footer + scroll-to-top

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,8 @@ import Depth from './personal/depth/Depth';
 import Cadence from './personal/cadence/Cadence';
 import Leak from './personal/leak/Leak';
 import Nerve from './personal/nerve/Nerve';
-
-const NON_BLOG_ROUTES = new Set(['/', '/cv', '/personal']);
+import ScrollToTop from './components/ScrollToTop';
+import { NON_BLOG_ROUTES } from './resources/routes';
 
 function App() {
     let routes = [];
@@ -53,6 +53,7 @@ function App() {
     return (
         <header className="App-header">
             <BrowserRouter>
+                <ScrollToTop />
                 <NavBar />
                 <Routes>
                     {routes}

--- a/src/blog.css
+++ b/src/blog.css
@@ -215,6 +215,91 @@
     max-width: 100%;
 }
 
+/* Related reading — end-of-post "Keep reading" footer */
+.RelatedReading {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-subtle);
+}
+
+.RelatedReading-heading {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+        'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+        'Helvetica Neue', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-dim);
+    margin: 0 0 1rem 0;
+}
+
+.RelatedReading-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.RelatedReading-card {
+    display: flex;
+    gap: 0.85rem;
+    align-items: center;
+    padding: 0.7rem;
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    background: var(--card-bg);
+    text-decoration: none;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.RelatedReading-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+}
+
+.RelatedReading-thumb {
+    width: 64px;
+    height: 64px;
+    flex-shrink: 0;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.RelatedReading-body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    min-width: 0;
+    /* Article layout is centered; keep card text flush-left regardless */
+    text-align: left;
+}
+
+.RelatedReading-title {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--text-bright);
+    line-height: 1.25;
+}
+
+.RelatedReading-date {
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    color: var(--text-dim);
+    margin-top: 0.15rem;
+}
+
+.RelatedReading-tags {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    color: var(--text-dim);
+}
+
 /* Mobile adjustments */
 @media only screen and (max-width: 800px) {
     .blog-page h1 {
@@ -223,5 +308,9 @@
 
     .blog-page .Content h2 {
         font-size: 1.2rem;
+    }
+
+    .RelatedReading-cards {
+        grid-template-columns: 1fr;
     }
 }

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -3,17 +3,9 @@ import { Tags } from '../resources/enums/Tags';
 import ThemeBadge from './ThemeBadge';
 import AudioPlayer from './AudioPlayer';
 import VideoPlayer from './VideoPlayer';
+import RelatedReading from './RelatedReading';
 import usePageTracking from '../analytics/usePageTracking';
-
-function formatDate(dateStr: string): string {
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-    return date.toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-    });
-}
+import { formatDate } from '../resources/formatDate';
 
 function Blog({
     route,
@@ -88,6 +80,7 @@ function Blog({
                     <img src={img2} className="App-logo" />
                 </figure>
             )}
+            {isBlogPost && <RelatedReading route={route} />}
         </div>
     );
 }

--- a/src/components/RelatedReading.tsx
+++ b/src/components/RelatedReading.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom';
+import allData from '../articles/allData';
+import { relatedArticles } from '../resources/relatedArticles';
+import { formatDate } from '../resources/formatDate';
+import ThemeBadge from './ThemeBadge';
+
+// End-of-post "Keep reading" footer. Surfaces the two most relevant other
+// posts (by shared theme, newest breaking ties) as small thumbnail cards.
+// Renders nothing off blog posts or when no candidates exist.
+function RelatedReading({ route }: { route: string }) {
+    const current = allData.find((a) => a.route === route);
+    if (!current) return null;
+
+    const related = relatedArticles(current, allData, 2);
+    if (related.length === 0) return null;
+
+    return (
+        <aside className="RelatedReading">
+            <h2 className="RelatedReading-heading">Keep reading</h2>
+            <div className="RelatedReading-cards">
+                {related.map((a) => {
+                    const thumb = require(`../articles/pics/${a.pics[0]}`);
+                    return (
+                        <Link
+                            key={a.route}
+                            to={a.route}
+                            className="RelatedReading-card"
+                        >
+                            <img
+                                src={thumb}
+                                alt=""
+                                className="RelatedReading-thumb"
+                                loading="lazy"
+                            />
+                            <div className="RelatedReading-body">
+                                <span className="RelatedReading-title">
+                                    {a.title}
+                                </span>
+                                {a.createdDate && (
+                                    <span className="RelatedReading-date">
+                                        {formatDate(a.createdDate)}
+                                    </span>
+                                )}
+                                {a.tags && a.tags.length > 0 && (
+                                    <span className="RelatedReading-tags">
+                                        <ThemeBadge tags={a.tags} size={12} />
+                                        <span>{a.tags.join(' · ')}</span>
+                                    </span>
+                                )}
+                            </div>
+                        </Link>
+                    );
+                })}
+            </div>
+        </aside>
+    );
+}
+
+export default RelatedReading;

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// React Router keeps the previous scroll position across route changes, so
+// navigating (e.g. via the Keep-reading footer or nav bar) can leave a new
+// article scrolled to the middle/bottom. Reset to the top on every path change.
+function ScrollToTop() {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+}
+
+export default ScrollToTop;

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,7 @@
 
 html,
 body {
+    margin: 0;
     background-color: var(--bg);
     font-family:
         -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/resources/formatDate.ts
+++ b/src/resources/formatDate.ts
@@ -1,0 +1,11 @@
+// Format a 'YYYY-MM-DD' article date as e.g. "June 27, 2026".
+// Parsed as local (not UTC) so the day never shifts across timezones.
+export function formatDate(dateStr: string): string {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    });
+}

--- a/src/resources/relatedArticles.test.ts
+++ b/src/resources/relatedArticles.test.ts
@@ -1,0 +1,67 @@
+import { relatedArticles } from './relatedArticles';
+import { ArticleProps } from './interfaces/ArticleProps';
+import { Tags } from './enums/Tags';
+
+// Minimal fixture — only the fields the ranker reads.
+function article(p: Partial<ArticleProps> & { route: string }): ArticleProps {
+    return {
+        title: p.route,
+        pics: ['x.jpg'],
+        caption: '',
+        content: [],
+        ...p,
+    } as ArticleProps;
+}
+
+const lean = article({ route: '/lean', tags: [Tags.Computation, Tags.Math], createdDate: '2026-06-27' });
+const phd = article({ route: '/phd', tags: [Tags.Math, Tags.Computation, Tags.Physics], createdDate: '2025-01-01' });
+const rust = article({ route: '/rust', tags: [Tags.Computation], createdDate: '2025-11-01' });
+const ai = article({ route: '/ai-engineering', tags: [Tags.Computation], createdDate: '2025-03-01' });
+const about = article({ route: '/about', tags: [Tags.Culture], createdDate: '2024-01-01' });
+const home = article({ route: '/', createdDate: '2020-01-01' });
+const cv = article({ route: '/cv', createdDate: '2020-01-01' });
+
+const all = [lean, phd, rust, ai, about, home, cv];
+
+describe('relatedArticles', () => {
+    it('ranks by tag overlap, descending', () => {
+        const result = relatedArticles(lean, all, 2);
+        // /phd shares 2 tags (Math, Computation) — must rank first.
+        expect(result[0].route).toBe('/phd');
+    });
+
+    it('breaks ties by most recent date', () => {
+        // /rust and /ai-engineering both share 1 tag; /rust is newer.
+        const result = relatedArticles(lean, all, 2);
+        expect(result[1].route).toBe('/rust');
+    });
+
+    it('excludes the current article', () => {
+        const routes = relatedArticles(lean, all, 5).map((a) => a.route);
+        expect(routes).not.toContain('/lean');
+    });
+
+    it('excludes non-blog pages (home, cv)', () => {
+        const routes = relatedArticles(lean, all, 10).map((a) => a.route);
+        expect(routes).not.toContain('/');
+        expect(routes).not.toContain('/cv');
+    });
+
+    it('excludes hidden articles', () => {
+        const hidden = article({ route: '/secret', tags: [Tags.Computation, Tags.Math], hidden: true });
+        const routes = relatedArticles(lean, [...all, hidden], 10).map((a) => a.route);
+        expect(routes).not.toContain('/secret');
+    });
+
+    it('returns at most `count` items', () => {
+        expect(relatedArticles(lean, all, 2)).toHaveLength(2);
+    });
+
+    it('fills remaining slots by recency when overlap runs out', () => {
+        // current shares no tags with anything → pure recency order.
+        const culture = article({ route: '/culture', tags: [Tags.Culture], createdDate: '2026-01-01' });
+        const result = relatedArticles(culture, [culture, phd, rust, ai], 2);
+        // rust (2025-11) newer than ai (2025-03) and phd (2025-01)
+        expect(result.map((a) => a.route)).toEqual(['/rust', '/ai-engineering']);
+    });
+});

--- a/src/resources/relatedArticles.ts
+++ b/src/resources/relatedArticles.ts
@@ -1,0 +1,38 @@
+import { ArticleProps } from './interfaces/ArticleProps';
+import { NON_BLOG_ROUTES } from './routes';
+
+/**
+ * Pick the articles most worth surfacing at the end of `current`.
+ *
+ * Ranking: most shared tags first; ties broken by most-recent `createdDate`.
+ * Excludes the current article, non-blog pages (home/cv/personal), and hidden
+ * articles. When tag overlap runs out, remaining slots fill by recency so the
+ * footer always offers `count` reads when that many candidates exist.
+ */
+export function relatedArticles(
+    current: ArticleProps,
+    all: ArticleProps[],
+    count = 2
+): ArticleProps[] {
+    const currentTags = new Set(current.tags ?? []);
+
+    return all
+        .filter(
+            (a) =>
+                a.route !== current.route &&
+                !a.hidden &&
+                !NON_BLOG_ROUTES.has(a.route)
+        )
+        .map((a) => ({
+            article: a,
+            overlap: (a.tags ?? []).filter((t) => currentTags.has(t)).length,
+            date: a.createdDate ?? '',
+        }))
+        .sort((x, y) =>
+            y.overlap !== x.overlap
+                ? y.overlap - x.overlap
+                : y.date.localeCompare(x.date)
+        )
+        .slice(0, count)
+        .map((s) => s.article);
+}

--- a/src/resources/routes.ts
+++ b/src/resources/routes.ts
@@ -1,0 +1,3 @@
+// Routes that are pages, not blog posts. Used to render blog-only chrome
+// (publish metadata, related reading) and to exclude these from candidate lists.
+export const NON_BLOG_ROUTES = new Set(['/', '/cv', '/personal']);


### PR DESCRIPTION
End-of-post "Keep reading" footer surfacing 2 relevant other posts (thumbnail + title + date + theme tag), ranked by shared-tag overlap with ties broken by recency. Excludes the current post, hidden drafts, and non-blog pages.

Also includes:
- ScrollToTop on route change (navigating between articles now lands at the top)
- Shared `formatDate` + `NON_BLOG_ROUTES` utils (dedup)
- Fix site-wide 8px horizontal overflow (reset default body margin)

Verified on desktop + mobile: layout, alignment, no overflow, scroll-to-top, correct ranking, hidden-post exclusion. 7/7 unit tests pass; build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)