### PR TITLE
Normalize IPv6 to /64 before hashing (stable user identity)

### DIFF
--- a/server/analytics/identity.test.ts
+++ b/server/analytics/identity.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert';
+import { networkKey, hashIp } from './identity';
+
+let passed = 0;
+function check(name: string, fn: () => void) {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+}
+
+console.log('networkKey:');
+
+check('IPv4 is kept whole', () => {
+    assert.strictEqual(networkKey('24.1.62.66'), '24.1.62.66');
+});
+
+check('two rotating IPv6 temp addresses in one /64 collapse to same key', () => {
+    const a = networkKey('2601:240:c600:e880:1116:4052:6074:b27b');
+    const b = networkKey('2601:240:c600:e880:1818:cc6c:2f58:b202');
+    assert.strictEqual(a, b);
+    assert.strictEqual(a, '2601:240:c600:e880::/64');
+});
+
+check('different /64 gives different key', () => {
+    assert.notStrictEqual(
+        networkKey('2601:240:c600:e880::1'),
+        networkKey('2601:240:c600:e881::1')
+    );
+});
+
+check(':: compression is expanded correctly', () => {
+    // 2601:240:: -> first four hextets are 2601:240:0:0
+    assert.strictEqual(networkKey('2601:240::abcd:1'), '2601:240:0:0::/64');
+});
+
+check('IPv4-mapped IPv6 unwraps to the IPv4', () => {
+    assert.strictEqual(networkKey('::ffff:24.1.62.66'), '24.1.62.66');
+});
+
+console.log('\nhashIp:');
+
+check('same network -> same hash (rotating IPv6 = one user)', () => {
+    const s = 'test-secret';
+    assert.strictEqual(
+        hashIp('2601:240:c600:e880:1116:4052:6074:b27b', s),
+        hashIp('2601:240:c600:e880:1818:cc6c:2f58:b202', s)
+    );
+});
+
+check('different IPv4 -> different hash', () => {
+    const s = 'test-secret';
+    assert.notStrictEqual(hashIp('24.1.62.66', s), hashIp('24.1.62.67', s));
+});
+
+check('hash is 32 hex chars and stores no raw IP', () => {
+    const h = hashIp('24.1.62.66', 'test-secret');
+    assert.match(h, /^[0-9a-f]{32}$/);
+    assert.ok(!h.includes('24.1'));
+});
+
+check('secret matters (different key -> different hash)', () => {
+    assert.notStrictEqual(hashIp('24.1.62.66', 'secretA'), hashIp('24.1.62.66', 'secretB'));
+});
+
+console.log(`\n${passed} passed`);

--- a/server/analytics/identity.ts
+++ b/server/analytics/identity.ts
@@ -1,13 +1,49 @@
 import { createHmac } from 'crypto';
 
 /**
- * Pseudonymous per-visitor id: a keyed one-way hash of the client IP.
+ * Reduce a client IP to a stable per-subscriber network key before hashing.
+ *
+ * IPv4: kept whole — one address ≈ one household/NAT ≈ one "user".
+ * IPv6: reduced to the /64 network prefix. Modern clients use IPv6 Privacy
+ *   Extensions (RFC 4941), rotating the 64-bit host part every few minutes, so
+ *   the full address is NOT stable per person. The /64 prefix is the subscriber
+ *   network (the IPv6 analogue of a single IPv4 address) and stays constant, so
+ *   this keeps one person as one user across their rotating addresses.
+ * IPv4-mapped IPv6 (::ffff:a.b.c.d): unwrapped to the underlying IPv4.
+ */
+export function networkKey(ip: string): string {
+    const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(ip);
+    if (mapped) return mapped[1];
+
+    if (ip.includes(':')) {
+        // Expand any :: compression, then keep the first 4 hextets (/64).
+        const [head, tail = ''] = ip.split('::');
+        const headParts = head ? head.split(':') : [];
+        const tailParts = tail ? tail.split(':') : [];
+        const fill = Math.max(0, 8 - headParts.length - tailParts.length);
+        const full = [...headParts, ...Array(fill).fill('0'), ...tailParts];
+        return (
+            full
+                .slice(0, 4)
+                .map((h) => (h === '' ? '0' : h.toLowerCase()))
+                .join(':') + '::/64'
+        );
+    }
+
+    return ip; // IPv4, or anything else, unchanged
+}
+
+/**
+ * Pseudonymous per-visitor id: a keyed one-way hash of the client's network key.
  *
  * The raw IP is never stored, so the analytics workbook holds no PII. Keyed
  * with a secret (SESSION_SECRET) so it can't be brute-forced from the small
- * IPv4 space. Deterministic: the same IP always maps to the same hash, which
- * is what lets us treat one IP as one "user" across visits.
+ * address space. Deterministic: the same network always maps to the same hash,
+ * which is what lets us treat one subscriber as one "user" across visits.
  */
 export function hashIp(ip: string, secret: string): string {
-    return createHmac('sha256', secret).update(ip).digest('hex').slice(0, 32);
+    return createHmac('sha256', secret)
+        .update(networkKey(ip))
+        .digest('hex')
+        .slice(0, 32);
 }


### PR DESCRIPTION
IPv6 Privacy Extensions rotate the host part, so hashing the full address fragments one person into many users. Reduce IPv6 to its /64 network prefix before hashing (IPv4 unchanged). Caught in prod smoke-test. 9 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)