### PR TITLE
Strip client port from req.ip before hashing (Azure XFF fix)

### DIFF
--- a/server/analytics/identity.test.ts
+++ b/server/analytics/identity.test.ts
@@ -37,6 +37,30 @@ check('IPv4-mapped IPv6 unwraps to the IPv4', () => {
     assert.strictEqual(networkKey('::ffff:24.1.62.66'), '24.1.62.66');
 });
 
+// The prod bug: Azure XFF is "IP:port" and the port rotates every connection.
+check('IPv4:port strips the port (same IP, diff ports -> same key)', () => {
+    assert.strictEqual(networkKey('24.1.62.66:54321'), '24.1.62.66');
+    assert.strictEqual(networkKey('24.1.62.66:54321'), networkKey('24.1.62.66:12345'));
+});
+
+check('[IPv6]:port strips brackets+port and still /64-collapses', () => {
+    assert.strictEqual(
+        networkKey('[2601:240:c600:e880:1116:4052:6074:b27b]:5555'),
+        '2601:240:c600:e880::/64'
+    );
+    assert.strictEqual(
+        networkKey('[2601:240:c600:e880:aaaa:bbbb:cccc:dddd]:9999'),
+        networkKey('[2601:240:c600:e880:1116:4052:6074:b27b]:5555')
+    );
+});
+
+check('bare IPv6 still works (colons not mistaken for a port)', () => {
+    assert.strictEqual(
+        networkKey('2601:240:c600:e880:1116:4052:6074:b27b'),
+        '2601:240:c600:e880::/64'
+    );
+});
+
 console.log('\nhashIp:');
 
 check('same network -> same hash (rotating IPv6 = one user)', () => {

--- a/server/analytics/identity.ts
+++ b/server/analytics/identity.ts
@@ -1,6 +1,24 @@
 import { createHmac } from 'crypto';
 
 /**
+ * Strip a trailing port (and IPv6 brackets) from an address.
+ *
+ * Azure App Service writes the client's `IP:port` into X-Forwarded-For, and
+ * Express's req.ip passes that through verbatim. The ephemeral port changes on
+ * every TCP connection, so leaving it in would make each request look like a
+ * new visitor. Handles `IPv4:port` and `[IPv6]:port`; bare IPv4/IPv6 pass
+ * through untouched (an IPv6 address's own colons are never mistaken for a port
+ * because that form is only matched inside brackets).
+ */
+function stripPort(ip: string): string {
+    const bracketed = /^\[([^\]]+)\](?::\d+)?$/.exec(ip); // [IPv6]:port
+    if (bracketed) return bracketed[1];
+    const v4port = /^(\d{1,3}(?:\.\d{1,3}){3}):\d+$/.exec(ip); // IPv4:port
+    if (v4port) return v4port[1];
+    return ip;
+}
+
+/**
  * Reduce a client IP to a stable per-subscriber network key before hashing.
  *
  * IPv4: kept whole — one address ≈ one household/NAT ≈ one "user".
@@ -11,7 +29,9 @@ import { createHmac } from 'crypto';
  *   this keeps one person as one user across their rotating addresses.
  * IPv4-mapped IPv6 (::ffff:a.b.c.d): unwrapped to the underlying IPv4.
  */
-export function networkKey(ip: string): string {
+export function networkKey(rawIp: string): string {
+    const ip = stripPort(rawIp);
+
     const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(ip);
     if (mapped) return mapped[1];
 


### PR DESCRIPTION
Azure App Service puts `IP:port` in X-Forwarded-For; the rotating ephemeral port made every request hash to a new "user." Strip the port (and IPv6 brackets) before the network key. Reproduced + fixed locally; 12 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)