### PR TITLE
Fix analytics read silently truncating newest events

### DIFF
--- a/server/analytics/excel.ts
+++ b/server/analytics/excel.ts
@@ -65,18 +65,36 @@ export async function appendEvents(rows: EventRow[]): Promise<void> {
     }
 }
 
+const PAGE = 500;
+
 export async function readAllEvents(): Promise<EventRow[]> {
     const out: EventRow[] = [];
-    let next: string | null = `${tableUrl()}/rows?$top=500`;
-    while (next) {
-        const res = await graphFetch(next);
+
+    // The workbook table `rows` endpoint does NOT return `@odata.nextLink`: a
+    // single request is silently capped at $top rows, so a nextLink loop stops
+    // after the first page and drops every row beyond it (the NEWEST events).
+    // Page explicitly with $skip against the true row count instead.
+    const countRes = await graphFetch(
+        `${tableUrl()}/dataBodyRange?$select=rowCount`,
+    );
+    if (!countRes.ok) {
+        throw new Error(
+            `Analytics row count failed: ${countRes.status} ${await countRes.text()}`,
+        );
+    }
+    const total = Number(
+        ((await countRes.json()) as { rowCount?: number }).rowCount ?? 0,
+    );
+
+    for (let skip = 0; skip < total; skip += PAGE) {
+        const res = await graphFetch(
+            `${tableUrl()}/rows?$top=${PAGE}&$skip=${skip}`,
+        );
         if (!res.ok) {
             throw new Error(`Analytics read failed: ${res.status} ${await res.text()}`);
         }
-        const json = (await res.json()) as {
-            value: { values: unknown[][] }[];
-            '@odata.nextLink'?: string;
-        };
+        const json = (await res.json()) as { value: { values: unknown[][] }[] };
+        if (!json.value?.length) break; // safety: never loop past the data
         for (const row of json.value) {
             const v = row.values?.[0];
             if (!v) continue;
@@ -93,7 +111,6 @@ export async function readAllEvents(): Promise<EventRow[]> {
                 ip_hash: unescape(v[7]),
             });
         }
-        next = json['@odata.nextLink'] ?? null;
     }
     return out;
 }


### PR DESCRIPTION
## Problem
The blog-analytics tool reported **0 views for July 18** despite real traffic. Root cause: Microsoft Graph's Excel table `rows` endpoint caps a read at `$top` and returns **no** `@odata.nextLink`, so `readAllEvents`' pagination loop stopped after the oldest 500 rows and silently dropped everything newer. The workbook had 651 rows, so recent days read as zero and busy days were undercounted (July 17: 168 → 206).

This also affects the live `/personal/analytics` dashboard, which reads through the same code path.

## Fix
Page explicitly: fetch the true row count from `.../dataBodyRange?$select=rowCount`, then read pages via `?$top=500&$skip=<offset>` until `skip >= rowCount`. No longer relies on a nextLink the endpoint never returns. Unbounded and correct as the table grows.

## Verification
Ran the analytics `query.ts` against the live workbook before/after:
- July 18: **0 → 112 views** / 24 sessions ✅
- July 17 corrected: 168 → 206 views
- Workbook total: 500 → 651 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)